### PR TITLE
fix @logger

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
     dopiaza_slack_exception_logger.listener:
         class: Dopiaza\Slack\ExceptionLoggerBundle\Service\ExceptionHandler
         arguments:
-            - @logger
+            - '@logger'
             - %kernel.environment%
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }


### PR DESCRIPTION
added quotes arround @logger to avoid error : 
`Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 6 (near "- @logger").`
